### PR TITLE
fixed `name_case` list-to-string conversion: do it for `messages_get_intent_users` but not for `users_get`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "vk-maria"
-version = "3.0.9"
+version = "3.0.10"
 description = "Simple Vk Bot synchronous framework"
 authors = ["lxstvayne"]
 license = "GPL-3.0"

--- a/vk_maria/utils.py
+++ b/vk_maria/utils.py
@@ -93,7 +93,7 @@ def args_converter(method):
                 kwargs[keyword] = ','.join(str(el) for el in value)
             elif keyword == 'media_type':
                 kwargs[keyword] = ','.join(value)
-            elif keyword == 'name_case':
+            elif keyword == 'name_case' and 'intent' in kwargs:
                 kwargs[keyword] = ','.join(value)
             elif keyword == 'market_country':
                 kwargs[keyword] = ','.join(str(el) for el in value)


### PR DESCRIPTION
`users_get` failed even without an explicit `name_case` value because the default value `'nom'` got converted to `'n,o,m'`.